### PR TITLE
Check *both* BT and Location states when one of them changes

### DIFF
--- a/app/src/main/java/lv/spkc/apturicovid/activity/BaseActivity.kt
+++ b/app/src/main/java/lv/spkc/apturicovid/activity/BaseActivity.kt
@@ -197,7 +197,7 @@ abstract class BaseActivity : DaggerAppCompatActivity() {
                     if (appStatusViewModel.isTrackingStateNotificationsEnabled()) {
                         BtNotificationManager.showNotification(this@BaseActivity)
                         lifecycleScope.launch(CovidCoroutineExceptionHandler(SWITCH_LOG_ERROR)) {
-                            exposureViewModel.changeExposureState(false)
+                            checkRequiredServicesState()
                         }
                     }
                 }
@@ -205,7 +205,7 @@ abstract class BaseActivity : DaggerAppCompatActivity() {
                 override fun onTurnedOn() {
                     BtNotificationManager.hideNotificationIfPresent(this@BaseActivity)
                     lifecycleScope.launch(CovidCoroutineExceptionHandler(SWITCH_LOG_ERROR)) {
-                        exposureViewModel.changeExposureState(true)
+                        checkRequiredServicesState()
                     }
                 }
             }
@@ -223,7 +223,7 @@ abstract class BaseActivity : DaggerAppCompatActivity() {
                     if (appStatusViewModel.isTrackingStateNotificationsEnabled()) {
                         LocationServicesNotificationManager.showNotification(this@BaseActivity)
                         lifecycleScope.launch(CovidCoroutineExceptionHandler(SWITCH_LOG_ERROR)) {
-                            exposureViewModel.changeExposureState(false)
+                            checkRequiredServicesState()
                         }
                     }
                 }
@@ -231,7 +231,7 @@ abstract class BaseActivity : DaggerAppCompatActivity() {
                 override fun onTurnedOn() {
                     LocationServicesNotificationManager.hideNotificationIfPresent(this@BaseActivity)
                     lifecycleScope.launch(CovidCoroutineExceptionHandler(SWITCH_LOG_ERROR)) {
-                        exposureViewModel.changeExposureState(true)
+                        checkRequiredServicesState()
                     }
                 }
             }


### PR DESCRIPTION
Fixes issue that shows tracing is on when only one of BT/Location switches has been turned on.

Precondition - both BT/Location must be off